### PR TITLE
Create RemoteTech_support_for_GeoLab_Antenna.cfg

### DIFF
--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/Malemute/RemoteTech_support_for_GeoLab_Antenna.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/Malemute/RemoteTech_support_for_GeoLab_Antenna.cfg
@@ -1,0 +1,22 @@
+ //RT Support for USI - Malemute Geology Lab
+
+//USI - Malemute Geology Lab
+@PART[Malemute_RoverScienceLab]:NEEDS[RemoteTech]
+{
+    !MODULE[ModuleDataTransmitter] {}
+       
+    %MODULE[ModuleRTAntenna] {
+        %Mode0OmniRange =  500000
+        %Mode1OmniRange = 5000000
+        %EnergyCost = 0.2
+                       
+        %TRANSMITTER
+        {
+            %PacketInterval = 0.3
+            %PacketSize = 2
+            %PacketResourceCost = 15.0
+        }
+    }
+    
+    %MODULE[ModuleSPUPassive] {}
+} 


### PR DESCRIPTION
Adds a MM file which enables RemoteTech support for the GeoLab.