### PR TITLE
Malamute long tank overly generous for USI-LS resources

### DIFF
--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/Malemute/Parts/RoverTankLong.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/Malemute/Parts/RoverTankLong.cfg
@@ -67,8 +67,8 @@ bulkheadProfiles = size1,srf
 	{
 		name = FSfuelSwitch
 		resourceNames = LiquidFuel,Oxidizer,ElectricCharge;LiquidFuel,ElectricCharge;MonoPropellant,ElectricCharge;Supplies,Mulch,ElectricCharge;Fertilizer,ElectricCharge
-		resourceAmounts = 225,275,2000;500,2000;500,2000;4500,150,2000;4500,2000
-		initialResourceAmounts = 225,275,2000;500,2000;500,2000;4500,0,2000;4500,2000
+		resourceAmounts = 225,275,2000;500,2000;500,2000;1900,100,2000;2000,2000
+		initialResourceAmounts = 225,275,2000;500,2000;500,2000;2000,0,2000;2000,2000
 		tankCost = 3000;3000;3000;3000;3000
 		basePartMass = 0.42
 		tankMass = 0;0;0;0;0


### PR DESCRIPTION
Changed USI-LS units to be more inline with other rugged USI rover unit to mass ratios.  Ratio was better than nonrugged Kontainers.
