### PR TITLE
Malamute Short tank is too stingy on USI-LS Resources

### DIFF
--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/Malemute/Parts/RoverTankShort.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/Malemute/Parts/RoverTankShort.cfg
@@ -61,8 +61,8 @@ bulkheadProfiles = size1,srf
 	{
 		name = FSfuelSwitch
 		resourceNames = LiquidFuel,Oxidizer;LiquidFuel;MonoPropellant;Supplies,Mulch;Fertilizer
-		resourceAmounts = 90,110;200;200;500,10;500
-		initialResourceAmounts = 90,110;200;200;500,0;500
+		resourceAmounts = 90,110;200;200;950,50;1000
+		initialResourceAmounts = 90,110;200;200;950,0;1000
 		tankCost = 3000;3000;3000;3000;3000
 		basePartMass = 0.2
 		tankMass = 0;0;0;0;0


### PR DESCRIPTION
Unit to mass ratio for the short container was stingy for USI-LS resources compared to other rover bays.  Bringing unit/mass ratio up to standard with other USI Rover bays.
