### PR TITLE
Fix geology lab's KerbNet access

### DIFF
--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/Malemute/Parts/RoverScienceLab.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/Malemute/Parts/RoverScienceLab.cfg
@@ -101,7 +101,7 @@ MODULE
 	MinimumFoV = 5
 	MaximumFoV = 90
 	AnomalyDetection = 0
-	RequiresAnimation = True
+	RequiresAnimation = False
 	DISPLAY_MODES
 	{
 		Mode = Resources


### PR DESCRIPTION
Unlike the stock narrow-band scanner, the geology lab doesn't have an
animation that represents its scanning activity, so it shouldn't require one
for KerbNet access to work.  This change fixes the lab's KerbNet window saying
"please verify that this scanner is properly activated", and makes it possible
to actually use KerbNet from the lab.